### PR TITLE
jiter 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
+    - python
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('rust') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
-    - {{ stdlib("c") }}
     - {{ compiler('rust') }}
     - maturin
     - cargo-bundle-licenses
@@ -40,8 +39,12 @@ test:
 about:
   home: https://crates.io/crates/jiter
   summary: Fast iterable JSON parser.
+  description: Fast iterable JSON parser.
   license: MIT
   license_file: crates/jiter/LICENSE
+  license_family: MIT
+  doc_url: https://docs.rs/jiter/latest/jiter/
+  dev_url: https://github.com/pydantic/jiter
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  missing_dso_whitelist:  # [s390x]
+    - "$RPATH/ld64.so.1"  # [s390x]
 
 requirements:
   build:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5991](https://anaconda.atlassian.net/browse/PKG-5991)
- [Upstream repository](https://github.com/pydantic/jiter/tree/v0.6.1)
- [Upstream changelog/diff](https://github.com/pydantic/jiter/releases)
- Relevant dependency PRs:
  - jiter 0.6.1 ➡️ openai1 .52.1

### Explanation of changes:

- Initialize feedstock
- include missing_dso_whitelist for s390x
- linter fixes


[PKG-5991]: https://anaconda.atlassian.net/browse/PKG-5991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ