### PR TITLE
jiter 0.16.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.16.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -28,13 +28,19 @@ requirements:
     - python
 
 test:
+  source_files:
+    - crates/jiter-python/tests
+    - crates/jiter/benches
   imports:
     - jiter
   requires:
     - pip
+    - pytest
+    - dirty-equals
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv crates/jiter-python/tests
 
 about:
   home: https://crates.io/crates/jiter

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,3 +58,5 @@ about:
 extra:
   recipe-maintainers:
     - jan-janssen
+  skip-lints:
+    - reachable_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jiter" %}
-{% set version = "0.12.0" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b
+  sha256: 7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
jiter 0.16.0 

**Destination channel:** Defaults

### Links

- [PKG-16535]
- dev_url:        https://github.com/pydantic/jiter/tree/v0.16.0
- conda_forge:    https://github.com/conda-forge/jiter-feedstock
- pypi:           https://pypi.org/project/jiter/0.16.0
- pypi inspector: https://inspector.pypi.io/project/jiter/0.16.0

### Explanation of changes:

- new version number


[PKG-16535]: https://anaconda.atlassian.net/browse/PKG-16535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ